### PR TITLE
Fix default VERSION value

### DIFF
--- a/option-returner/app/main.py
+++ b/option-returner/app/main.py
@@ -6,7 +6,7 @@ import random
 import os
 
 
-version = os.getenv("VERSION", "v3.0.0")
+version = os.getenv("VERSION", "")
 health = 200
 
 app = FastAPI()


### PR DESCRIPTION
Use empty string as VERSION default value for the `/eigen/node/version` endpoint in the option-returner. Currently we was using an old value `v3.0.0`.
 A new tag with version `v0.2.1` should be created after merging this PR.

